### PR TITLE
Correcting calculation of the singularity spectrum. Adding more examples.

### DIFF
--- a/MFDFA/__init__.py
+++ b/MFDFA/__init__.py
@@ -4,6 +4,6 @@ from .emddetrender import detrendedtimeseries, IMFs
 from . import singspect
 
 __name__ = "MFDFA"
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __author__ = "Leonardo Rydin Gorjão"
-__copyright__ = "Copyright 2019-2021 Leonardo Rydin Gorjão, MIT License"
+__copyright__ = "Copyright 2019-2022 Leonardo Rydin Gorjão, MIT License"

--- a/MFDFA/singspect.py
+++ b/MFDFA/singspect.py
@@ -37,7 +37,7 @@ def singularity_spectrum(lag: np.array, mfdfa: np.ndarray, q: np.array,
     q: np.array
         Fractal exponents used. Must be more than 2 points.
 
-    lim: list (default `[1, lag.size//2]`)
+    lim: list (default `[int(lag.size // 1.5), int(lag.size // 8)]`)
         List of lower and upper lag limits. If none, the polynomial fittings
         will be restrict to half the maximal lag and discard the first lag
         point.
@@ -72,7 +72,7 @@ def singularity_spectrum(lag: np.array, mfdfa: np.ndarray, q: np.array,
 
     # if no limits given
     if lim[0] is None and lim[1] is None:
-        lim = [1, lag.size // 2]
+        lim = [int(lag.size // 8), int(lag.size // 1.5)]
 
     # clean q
     q = _clean_q(q)
@@ -117,7 +117,7 @@ def scaling_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
     q: np.array
         Fractal exponents used. Must be more than 2 points.
 
-    lim: list (default `[1, lag.size//2]`)
+    lim: list (default `[int(lag.size // 1.5), int(lag.size // 8)]`)
         List of lower and upper lag limits. If none, the polynomial fittings
         will be restrict to half the maximal lag and discard the first lag
         point.
@@ -152,7 +152,7 @@ def scaling_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
 
     # if no limits given
     if lim[0] is None and lim[1] is None:
-        lim = [1, lag.size // 2]
+        lim = [int(lag.size // 8), int(lag.size // 1.5)]
 
     # clean q
     q = _clean_q(q)
@@ -184,7 +184,7 @@ def hurst_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
     q: np.array
         Fractal exponents used. Must be more than 2 points.
 
-    lim: list (default `[1, lag.size//2]`)
+    lim: list (default `[int(lag.size // 1.5), int(lag.size // 8)]`)
         List of lower and upper lag limits. If none, the polynomial fittings
         will be restrict to half the maximal lag and discard the first lag
         point.
@@ -217,7 +217,7 @@ def hurst_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
 
     # if no limits given
     if lim[0] is None and lim[1] is None:
-        lim = [1, lag.size // 2]
+        lim = [int(lag.size // 8), int(lag.size // 1.5)]
 
     # clean q
     q = _clean_q(q)
@@ -229,7 +229,7 @@ def hurst_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
 
 
 def _slopes(lag: np.array, mfdfa: np.ndarray, q: np.array,
-            lim: list = [None, None], interpolate: int = False
+            lim: list = [None, None], modified=True, interpolate: int = False
             ) -> np.array:
     """
     Extra the slopes of each `q` power obtained with MFDFA to later produce
@@ -243,7 +243,7 @@ def _slopes(lag: np.array, mfdfa: np.ndarray, q: np.array,
 
     # if no limits given
     if lim[0] is None and lim[1] is None:
-        lim = [lag[1], lag[lag.size // 2]]
+        lim = [int(lag.size // 8), int(lag.size // 1.5)]
 
     # clean q
     q = _clean_q(q)
@@ -265,7 +265,7 @@ def _slopes(lag: np.array, mfdfa: np.ndarray, q: np.array,
         slopes[i] = polyfit(np.log(lag[lim[0]:lim[1]]),
                             np.log(mfdfa[lim[0]:lim[1], i]),
                             1
-                            )[1]
+                            )[1] - 1
 
     return slopes
 
@@ -418,7 +418,7 @@ def _plotter(x: np.array, y: np.array) -> Tuple['plt.fig', 'plt.Axes']:
 
     fig, ax = plt.subplots(1, 1)
 
-    ax.plot(x, y, lw=2, color='black')
+    ax.plot(x, y, 'o', color='black')
 
     fig.tight_layout()
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ print('Estimated H = '+'{:.3f}'.format(H_hat[0]))
 You can find more about multifractality in the [documentation](https://mfdfa.readthedocs.io/en/latest/1dLevy.html).
 
 # Changelog
+- Version 0.4.2 - Corrected spectral plots. Added [examples](https://github.com/LRydin/MFDFA/tree/master/examples) from the paper. 
 - Version 0.4.1 - Added conventional spectral plots as _h(q)_ vs _q_, _τ(q)_ vs _q_, and _f(α)_ vs _α_.
 - Version 0.4 - EMD is now optional. Restored back compatibility: py3.3 to py3.9. For EMD py3.6 or larger is needed.
 - Version 0.3 - Adding EMD detrending. First release. PyPI code.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,8 +26,8 @@ copyright = '2019-2021 Leonardo Rydin'
 author = 'Leonardo Rydin'
 
 # The full version, including alpha/beta/rc tags
-release = '0.4.1'
-version = '0.4.1'
+release = '0.4.2'
+version = '0.4.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="MFDFA",
-    version="0.4.1",
+    version="0.4.2",
     author="Leonardo Rydin Gorjao",
     author_email="leonardo.rydin@gmail.com",
     description="Multifractal Detrended Fluctuation Analysis in Python",
@@ -22,5 +22,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     license="MIT License",
-    python_requires='>=3.5',
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
Correcting calculation of the singularity spectrum, there was a vital `-1` at [L268](https://github.com/LRydin/MFDFA/blob/a1d576f290023acbe667000172d2f2ca0d20ee17/MFDFA/singspect.py#L268). Adding more [examples](https://github.com/LRydin/MFDFA/tree/master/examples).

Bumping to `v0.4.2`.