### PR TITLE
v0.4.3 - Correcting negative α values in the singularity spectrum

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Testing standard packages with coverage
       run: |
-        coverage run -m pytest -rP test/test_exceptions.py test/test_fgn.py test/test_MFDFA.py test/test_speed.py
+        coverage run -m pytest -rP test/test_exceptions.py test/test_fgn.py test/test_MFDFA.py test/test_speed.py test/test_spectrum.py
 
     - name: Install extra dependencies for extra packages
       if: ${{ matrix.python-version == 3.6 }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install coverage pytest
+        pip install scipy
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Testing standard packages with coverage
       run: |
@@ -40,6 +41,7 @@ jobs:
       run: |
         pip install EMD-signal
         pip install matplotlib
+        pip install scipy
     - name: Testing extra packages with coverage
       if: ${{ matrix.python-version == 3.6 }}
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install coverage pytest
-        pip install scipy
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Testing standard packages with coverage
       run: |

--- a/MFDFA/__init__.py
+++ b/MFDFA/__init__.py
@@ -4,6 +4,6 @@ from .emddetrender import detrendedtimeseries, IMFs
 from . import singspect
 
 __name__ = "MFDFA"
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __author__ = "Leonardo Rydin Gorjão"
 __copyright__ = "Copyright 2019-2022 Leonardo Rydin Gorjão, MIT License"

--- a/MFDFA/singspect.py
+++ b/MFDFA/singspect.py
@@ -74,11 +74,11 @@ def singularity_spectrum(lag: np.array, mfdfa: np.ndarray, q: np.array,
     """
 
     # if no lower limit is given
-    if lim[0]:
+    if not lim[0]:
         lim[0] = int(lag.size // 8)
 
     # if no upper limit is given
-    if lim[1]:
+    if not lim[1]:
          lim[1] = int(lag.size // 1.5)
 
     # clean q
@@ -157,11 +157,11 @@ def scaling_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
     """
 
     # if no lower limit is given
-    if lim[0]:
+    if not lim[0]:
         lim[0] = int(lag.size // 8)
 
     # if no upper limit is given
-    if lim[1]:
+    if not lim[1]:
          lim[1] = int(lag.size // 1.5)
 
     # clean q
@@ -228,11 +228,11 @@ def hurst_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
     """
 
     # if no lower limit is given
-    if lim[0]:
+    if not lim[0]:
         lim[0] = int(lag.size // 8)
 
     # if no upper limit is given
-    if lim[1]:
+    if not lim[1]:
          lim[1] = int(lag.size // 1.5)
 
     # clean q
@@ -258,11 +258,11 @@ def _slopes(lag: np.array, mfdfa: np.ndarray, q: np.array,
     """
 
     # if no lower limit is given
-    if lim[0]:
+    if not lim[0]:
         lim[0] = int(lag.size // 8)
 
     # if no upper limit is given
-    if lim[1]:
+    if not lim[1]:
          lim[1] = int(lag.size // 1.5)
 
     # clean q

--- a/MFDFA/singspect.py
+++ b/MFDFA/singspect.py
@@ -11,6 +11,7 @@ import numpy as np
 from numpy.polynomial.polynomial import polyfit
 
 __all__ = [
+    'singularity_spectrum',
     'scaling_exponents',
     'hurst_exponents',
     'singularity_spectrum_plot',
@@ -20,11 +21,13 @@ __all__ = [
 
 
 def singularity_spectrum(lag: np.array, mfdfa: np.ndarray, q: np.array,
-                         lim: list = [None, None], interpolate: int = False
+                         lim: list = [[],[]], interpolate: int = False
                          ) -> Tuple[np.array, np.array]:
     """
     Extract the slopes of the fluctuation function to further obtain the
-    singularity strength `α` and singularity spectrum `f(α)`.
+    singularity strength `α` and singularity spectrum `f(α)`. It is important to
+    note that `α` will be centred `>1` for most cases because of the increase in
+    regularity in MFDFA.
 
     Parameters
     ----------
@@ -38,9 +41,9 @@ def singularity_spectrum(lag: np.array, mfdfa: np.ndarray, q: np.array,
         Fractal exponents used. Must be more than 2 points.
 
     lim: list (default `[int(lag.size // 1.5), int(lag.size // 8)]`)
-        List of lower and upper lag limits. If none, the polynomial fittings
-        will be restrict to half the maximal lag and discard the first lag
-        point.
+        List of lower and upper lag limits. If you wish to consider the full
+        range, use `None` to unbound the limits (lower or upper) and thus
+        consider the full lag, e.g., `lim=[None, None]`.
 
     interpolate: int (default False)
         Interpolates the `q` space to smoothed the singularity spectrum. Not
@@ -70,9 +73,13 @@ def singularity_spectrum(lag: np.array, mfdfa: np.ndarray, q: np.array,
         A, 316(1-4), 87–114, 2002.
     """
 
-    # if no limits given
-    if lim[0] is None and lim[1] is None:
-        lim = [int(lag.size // 8), int(lag.size // 1.5)]
+    # if no lower limit is given
+    if lim[0]:
+        lim[0] = int(lag.size // 8)
+
+    # if no upper limit is given
+    if lim[1]:
+         lim[1] = int(lag.size // 1.5)
 
     # clean q
     q = _clean_q(q)
@@ -90,7 +97,7 @@ def singularity_spectrum(lag: np.array, mfdfa: np.ndarray, q: np.array,
 
 
 def scaling_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
-                      lim: list = [None, None], interpolate: int = False
+                      lim: list = [[],[]], interpolate: int = False
                       ) -> Tuple[np.array, np.array]:
     """
     Calculate the multifractal scaling exponents `τ(q)`, which is given by
@@ -101,10 +108,9 @@ def scaling_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
 
     To evaluate the scaling exponent `τ(q)`, plot it vs `q`. If the
     relation between `τ(q)` is linear, the data is monofractal. If
-    not, the data is multifractal.
-    Note that these measures rarely match the theoretical expectation,
-    thus a variation of ± 0.25 is absolutely reasonable.
-
+    not, the data is multifractal. Note that these measures rarely match the
+    theoretical expectation,  thus a variation of ± 0.25 is absolutely
+    reasonable.
 
     Parameters
     ----------
@@ -150,9 +156,13 @@ def scaling_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
         A, 316(1-4), 87–114, 2002.
     """
 
-    # if no limits given
-    if lim[0] is None and lim[1] is None:
-        lim = [int(lag.size // 8), int(lag.size // 1.5)]
+    # if no lower limit is given
+    if lim[0]:
+        lim[0] = int(lag.size // 8)
+
+    # if no upper limit is given
+    if lim[1]:
+         lim[1] = int(lag.size // 1.5)
 
     # clean q
     q = _clean_q(q)
@@ -164,14 +174,16 @@ def scaling_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
 
 
 def hurst_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
-                    lim: list = [None, None], interpolate: int = False
+                    lim: list = [[],[]], interpolate: int = False
                     ) -> Tuple[np.array, np.array]:
     """
     Calculate the generalised Hurst exponents `h(q)` from MFDFA, which
     are simply the slopes of each DFA for various `q` values.
 
     Note that these measures rarely match the theoretical expectation,
-    thus a variation of ± 0.25 is absolutely reasonable.
+    thus a variation of ± 0.25 is absolutely reasonable. It is important to
+    note that `h(q)` will have values `>1` for most cases because of the
+    increase in regularity in MFDFA.
 
     Parameters
     ----------
@@ -185,9 +197,9 @@ def hurst_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
         Fractal exponents used. Must be more than 2 points.
 
     lim: list (default `[int(lag.size // 1.5), int(lag.size // 8)]`)
-        List of lower and upper lag limits. If none, the polynomial fittings
-        will be restrict to half the maximal lag and discard the first lag
-        point.
+        List of lower and upper lag limits. If you wish to consider the full
+        range, use `None` to unbound the limits (lower or upper) and thus
+        consider the full lag, e.g., `lim=[None, None]`.
 
     interpolate: int (default False)
         Interpolates the `q` space to smoothed the singularity spectrum. Not
@@ -215,9 +227,13 @@ def hurst_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
         A, 316(1-4), 87–114, 2002.
     """
 
-    # if no limits given
-    if lim[0] is None and lim[1] is None:
-        lim = [int(lag.size // 8), int(lag.size // 1.5)]
+    # if no lower limit is given
+    if lim[0]:
+        lim[0] = int(lag.size // 8)
+
+    # if no upper limit is given
+    if lim[1]:
+         lim[1] = int(lag.size // 1.5)
 
     # clean q
     q = _clean_q(q)
@@ -241,9 +257,13 @@ def _slopes(lag: np.array, mfdfa: np.ndarray, q: np.array,
 
     """
 
-    # if no limits given
-    if lim[0] is None and lim[1] is None:
-        lim = [int(lag.size // 8), int(lag.size // 1.5)]
+    # if no lower limit is given
+    if lim[0]:
+        lim[0] = int(lag.size // 8)
+
+    # if no upper limit is given
+    if lim[1]:
+         lim[1] = int(lag.size // 1.5)
 
     # clean q
     q = _clean_q(q)

--- a/MFDFA/singspect.py
+++ b/MFDFA/singspect.py
@@ -21,7 +21,7 @@ __all__ = [
 
 
 def singularity_spectrum(lag: np.array, mfdfa: np.ndarray, q: np.array,
-                         lim: list = [[],[]], interpolate: int = False
+                         lim: list = [False, False], interpolate: int = False
                          ) -> Tuple[np.array, np.array]:
     """
     Extract the slopes of the fluctuation function to further obtain the
@@ -74,11 +74,11 @@ def singularity_spectrum(lag: np.array, mfdfa: np.ndarray, q: np.array,
     """
 
     # if no lower limit is given
-    if not lim[0]:
+    if lim[0] is False:
         lim[0] = int(lag.size // 8)
 
     # if no upper limit is given
-    if not lim[1]:
+    if lim[1] is False:
          lim[1] = int(lag.size // 1.5)
 
     # clean q
@@ -97,7 +97,7 @@ def singularity_spectrum(lag: np.array, mfdfa: np.ndarray, q: np.array,
 
 
 def scaling_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
-                      lim: list = [[],[]], interpolate: int = False
+                      lim: list = [False, False], interpolate: int = False
                       ) -> Tuple[np.array, np.array]:
     """
     Calculate the multifractal scaling exponents `τ(q)`, which is given by
@@ -157,11 +157,11 @@ def scaling_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
     """
 
     # if no lower limit is given
-    if not lim[0]:
+    if lim[0] is False:
         lim[0] = int(lag.size // 8)
 
     # if no upper limit is given
-    if not lim[1]:
+    if lim[1] is False:
          lim[1] = int(lag.size // 1.5)
 
     # clean q
@@ -174,7 +174,7 @@ def scaling_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
 
 
 def hurst_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
-                    lim: list = [[],[]], interpolate: int = False
+                    lim: list = [False, False], interpolate: int = False
                     ) -> Tuple[np.array, np.array]:
     """
     Calculate the generalised Hurst exponents `h(q)` from MFDFA, which
@@ -228,11 +228,11 @@ def hurst_exponents(lag: np.array, mfdfa: np.ndarray, q: np.array,
     """
 
     # if no lower limit is given
-    if not lim[0]:
+    if lim[0] is False:
         lim[0] = int(lag.size // 8)
 
     # if no upper limit is given
-    if not lim[1]:
+    if lim[1] is False:
          lim[1] = int(lag.size // 1.5)
 
     # clean q
@@ -258,11 +258,11 @@ def _slopes(lag: np.array, mfdfa: np.ndarray, q: np.array,
     """
 
     # if no lower limit is given
-    if not lim[0]:
+    if lim[0] is False:
         lim[0] = int(lag.size // 8)
 
     # if no upper limit is given
-    if not lim[1]:
+    if lim[1] is False:
          lim[1] = int(lag.size // 1.5)
 
     # clean q

--- a/MFDFA/singspect.py
+++ b/MFDFA/singspect.py
@@ -265,7 +265,7 @@ def _slopes(lag: np.array, mfdfa: np.ndarray, q: np.array,
         slopes[i] = polyfit(np.log(lag[lim[0]:lim[1]]),
                             np.log(mfdfa[lim[0]:lim[1], i]),
                             1
-                            )[1] - 1
+                            )[1]
 
     return slopes
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ print('Estimated H = '+'{:.3f}'.format(H_hat[0]))
 You can find more about multifractality in the [documentation](https://mfdfa.readthedocs.io/en/latest/1dLevy.html).
 
 # Changelog
-- Version 0.4.2 - Corrected spectral plots. Added [examples](https://github.com/LRydin/MFDFA/tree/master/examples) from the paper. 
+- Version 0.4.3 - Reverting negative values in the estimation of the singularity strenght α.
+- Version 0.4.2 - Corrected spectral plots. Added [examples](https://github.com/LRydin/MFDFA/tree/master/examples) from the paper.
 - Version 0.4.1 - Added conventional spectral plots as _h(q)_ vs _q_, _τ(q)_ vs _q_, and _f(α)_ vs _α_.
 - Version 0.4 - EMD is now optional. Restored back compatibility: py3.3 to py3.9. For EMD py3.6 or larger is needed.
 - Version 0.3 - Adding EMD detrending. First release. PyPI code.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,12 +22,12 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'MFDFA'
-copyright = '2019-2021 Leonardo Rydin'
+copyright = '2019-2022 Leonardo Rydin'
 author = 'Leonardo Rydin'
 
 # The full version, including alpha/beta/rc tags
-release = '0.4.2'
-version = '0.4.2'
+release = '0.4.3'
+version = '0.4.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="MFDFA",
-    version="0.4.2",
+    version="0.4.3",
     author="Leonardo Rydin Gorjao",
     author_email="leonardo.rydin@gmail.com",
     description="Multifractal Detrended Fluctuation Analysis in Python",

--- a/test/test_MFDFA.py
+++ b/test/test_MFDFA.py
@@ -24,33 +24,33 @@ def test_MFDFA():
                 pass
 
             # Testing simple FA (order = 0)
-            lag, dfa = MFDFA(X, lag = lag, q = q, order = 0)
+            lag, dfa = MFDFA(X, lag=lag, q=q, order=0)
 
             assert dfa.ndim == 2, "Output is not 2 dimensional"
             assert dfa.shape[1] <= q.shape[0], "Output shape mismatch"
 
             # Testing conventional DFA (order = 1)
-            lag, dfa = MFDFA(X, lag = lag, q = q, order = 1)
+            lag, dfa = MFDFA(X, lag=lag, q=q, order=1)
 
             assert dfa.ndim == 2, "Output is not 2 dimensional"
             assert dfa.shape[1] <= q.shape[0], "Output shape mismatch"
 
             # Testing conventional MFDFA with stats
-            lag, dfa, dfa_std = MFDFA(X, lag = lag, q = q, order = 2,
+            lag, dfa, dfa_std = MFDFA(X, lag=lag, q=q, order=2,
               stat = True)
 
             assert dfa.ndim == 2, "Output is not 2 dimensional"
             assert dfa.shape[1] <= q.shape[0], "Output shape mismatch"
 
             # Testing modified = True option
-            lag, dfa, dfa_std = MFDFA(X, lag = lag, q = q, order = 2,
+            lag, dfa, dfa_std = MFDFA(X, lag=lag, q=q, order=2,
               modified = True, stat = True)
 
             assert dfa.ndim == 2, "Output is not 2 dimensional"
             assert dfa.shape[1] <= q.shape[0], "Output shape mismatch"
 
             # Testing eDFA extension
-            lag, dfa, edfa = MFDFA(X, lag = lag, q = q, order = 3,
+            lag, dfa, edfa = MFDFA(X, lag=lag, q=q, order=3,
               stat = False, extensions = {'eDFA':True})
 
             assert dfa.ndim == 2, "Output is not 2 dimensional"
@@ -58,18 +58,18 @@ def test_MFDFA():
             assert dfa.shape[1] <= q.shape[0], "Output shape mismatch"
 
             # Testing moving window
-            lag, dfa = MFDFA(X, lag = lag, q = q, order = 1,
+            lag, dfa = MFDFA(X, lag=lag, q=q, order=1,
               stat = False, extensions = {'window': 5})
 
             # Testing moving window witg order = 0
-            lag, dfa = MFDFA(X, lag = lag, q = q, order = 0,
+            lag, dfa = MFDFA(X, lag=lag, q=q, order=0,
               stat = False, extensions = {'window': 5})
 
             assert dfa.ndim == 2, "Output is not 2 dimensional"
             assert dfa.shape[1] <= q.shape[0], "Output shape mismatch"
 
             # Testing moving window and eDFA with stats = True
-            lag, dfa, dfa_std, edfa = MFDFA(X, lag = lag, q = q, order = 1,
+            lag, dfa, dfa_std, edfa = MFDFA(X, lag=lag, q=q, order=1,
               stat = True, extensions = {'eDFA':True, 'window': 5})
 
             assert dfa.ndim == 2, "Output is not 2 dimensional"

--- a/test/test_MFDFA_extras.py
+++ b/test/test_MFDFA_extras.py
@@ -17,7 +17,7 @@ def test_MFDFA():
                   ).astype(int) + 1
                 )
 
-            lag, dfa = MFDFA(X, lag = lag, q = q, order = 0,
+            lag, dfa = MFDFA(X, lag=lag, q=q, order=0,
               modified = True, stat = False, extensions = {'EMD': [0]})
 
             assert dfa.ndim == 2, "Output is not 2 dimensional"

--- a/test/test_spectrum.py
+++ b/test/test_spectrum.py
@@ -11,7 +11,7 @@ from MFDFA import singspect
 
 def test_spectrum():
     for N in [1000, 10000]:
-        for q_list in [6, 12, 21]:
+        for q_list in [6, 12, 21, 41]:
 
             alpha = 1.5
             X = levy_stable.rvs(alpha, beta=0, size=N)
@@ -19,26 +19,28 @@ def test_spectrum():
             q = np.linspace(-10, 10, q_list)
             q = q[q!=0.0]
 
-            print(q)
             lag = np.unique(
                   np.logspace(
                   0, np.log10(X.size // 4), 55
-                  ).astype(int) + 1
+                  ).astype(int) + 3
                 )
 
             lag, dfa = MFDFA(X, lag = lag, q = q, order = 1)
 
             alpha, f  = singspect.singularity_spectrum(lag, dfa, q = q)
-            _ = singspect.singularity_spectrum_plot(alpha, f);
+
+            _ = singspect.singularity_spectrum(lag, dfa, q=q, lim=[None, None])
+            _ = singspect.singularity_spectrum_plot(alpha, f)
+
             assert alpha.shape[0] == f.shape[0], "Output shape mismatch"
             assert alpha.shape[0] == q.shape[0], "Output shape mismatch"
 
-            q, tau = singspect.scaling_exponents(lag, dfa, q = q)
-            _ = singspect.scaling_exponents_plot(q, tau);
+            q, tau = singspect.scaling_exponents(lag, dfa, q=q)
+            _ = singspect.scaling_exponents_plot(q, tau)
             assert tau.shape[0] == q.shape[0], "Output shape mismatch"
 
-            q, hq = singspect.hurst_exponents(lag, dfa, q = q)
-            _ = singspect.hurst_exponents_plot(q, hq);
+            q, hq = singspect.hurst_exponents(lag, dfa, q=q)
+            _ = singspect.hurst_exponents_plot(q, hq)
             assert hq.shape[0] == q.shape[0], "Output shape mismatch"
 
             try:

--- a/test/test_spectrum.py
+++ b/test/test_spectrum.py
@@ -3,8 +3,6 @@ import numpy as np
 import sys
 sys.path.append("../")
 
-from scipy.stats import levy_stable
-
 from MFDFA import MFDFA
 from MFDFA import singspect
 
@@ -12,8 +10,7 @@ def test_spectrum():
     for N in [1000, 10000]:
         for q_list in [6, 12, 21, 41]:
 
-            alpha = 1.5
-            X = levy_stable.rvs(alpha, beta=0, size=N)
+            X = np.cumsum(np.random.normal(0, 5, size=N))
 
             q = np.linspace(-10, 10, q_list)
             q = q[q!=0.0]

--- a/test/test_spectrum.py
+++ b/test/test_spectrum.py
@@ -21,9 +21,9 @@ def test_spectrum():
                   ).astype(int) + 3
                 )
 
-            lag, dfa = MFDFA(X, lag = lag, q = q, order = 1)
+            lag, dfa = MFDFA(X, lag=lag, q=q, order=1)
 
-            alpha, f  = singspect.singularity_spectrum(lag, dfa, q = q)
+            alpha, f  = singspect.singularity_spectrum(lag, dfa, q=q)
 
             _ = singspect.singularity_spectrum(lag, dfa, q=q, lim=[None, None])
 

--- a/test/test_spectrum_plots.py
+++ b/test/test_spectrum_plots.py
@@ -4,7 +4,6 @@ import sys
 sys.path.append("../")
 
 import matplotlib.pyplot as plt
-from scipy.stats import levy_stable
 
 from MFDFA import MFDFA
 from MFDFA import singspect
@@ -13,8 +12,7 @@ def test_spectrum():
     for N in [1000, 10000]:
         for q_list in [6, 12, 21, 41]:
 
-            alpha = 1.5
-            X = levy_stable.rvs(alpha, beta=0, size=N)
+            X = np.cumsum(np.random.normal(0, 5, size=N))
 
             q = np.linspace(-10, 10, q_list)
             q = q[q!=0.0]

--- a/test/test_spectrum_plots.py
+++ b/test/test_spectrum_plots.py
@@ -3,6 +3,7 @@ import numpy as np
 import sys
 sys.path.append("../")
 
+import matplotlib.pyplot as plt
 from scipy.stats import levy_stable
 
 from MFDFA import MFDFA
@@ -29,14 +30,17 @@ def test_spectrum():
             alpha, f  = singspect.singularity_spectrum(lag, dfa, q = q)
 
             _ = singspect.singularity_spectrum(lag, dfa, q=q, lim=[None, None])
+            _ = singspect.singularity_spectrum_plot(alpha, f)
 
             assert alpha.shape[0] == f.shape[0], "Output shape mismatch"
             assert alpha.shape[0] == q.shape[0], "Output shape mismatch"
 
             q, tau = singspect.scaling_exponents(lag, dfa, q=q)
+            _ = singspect.scaling_exponents_plot(q, tau)
             assert tau.shape[0] == q.shape[0], "Output shape mismatch"
 
             q, hq = singspect.hurst_exponents(lag, dfa, q=q)
+            _ = singspect.hurst_exponents_plot(q, hq)
             assert hq.shape[0] == q.shape[0], "Output shape mismatch"
 
             try:

--- a/test/test_spectrum_plots.py
+++ b/test/test_spectrum_plots.py
@@ -23,9 +23,9 @@ def test_spectrum():
                   ).astype(int) + 3
                 )
 
-            lag, dfa = MFDFA(X, lag = lag, q = q, order = 1)
+            lag, dfa = MFDFA(X, lag=lag, q=q, order=1)
 
-            alpha, f  = singspect.singularity_spectrum(lag, dfa, q = q)
+            alpha, f  = singspect.singularity_spectrum(lag, dfa, q=q)
 
             _ = singspect.singularity_spectrum(lag, dfa, q=q, lim=[None, None])
             _ = singspect.singularity_spectrum_plot(alpha, f)


### PR DESCRIPTION
In `v0.4.2` I've changed the standard by which α in estimated, in the basis of subtracting `1` to the calculation of the slopes due to the _unjustified_ assumption that data is always a motion. This naturally lead to negative values of α for noises and any data that is shuffled. Serious faceplant here :|. I've corrected this and now the estimated α should be correct. Note that 'nasty' data might still show negative α -- estimation is a subtle art. This should close issue #34.

---

I can also close issue my own #2 .